### PR TITLE
Add extra-spec entry for Azure Confidential VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ To this end, this provider supports the following extra specs schema:
             "type": "boolean",
             "description": "Allocate a public IP to the VM."
         },
+        "confidential": {
+            "type": "boolean",
+            "description": "The selected virtual machine size is confidential."
+        },
         "open_inbound_ports": {
             "type": "object",
             "description": "A map of protocol to list of inbound ports to open.",


### PR DESCRIPTION
In the Confidential Containers project we have a requirement to run CI jobs on Confidential VMs to test remote attestation software, hence the flag.