### PR TITLE
Add new knobs for runner creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ To this end, this provider supports the following extra specs schema:
             "type": "boolean",
             "description": "The selected virtual machine size is confidential."
         },
+        "use_ephemeral_storage": {
+            "type": "boolean",
+            "description": "Use ephemeral storage for the VM."
+        },
+        "use_accelerated_networking": {
+            "type": "boolean",
+            "description": "Use accelerated networking for the VM."
+        },
         "open_inbound_ports": {
             "type": "object",
             "description": "A map of protocol to list of inbound ports to open.",
@@ -129,6 +137,10 @@ To this end, this provider supports the following extra specs schema:
         "storage_account_type": {
             "type": "string",
             "description": "Azure storage account type. Default is Standard_LRS."
+        },
+        "virtual_network_cidr": {
+            "type": "string",
+            "description": "The CIDR for the virtual network."
         },
         "disk_size_gb": {
             "type": "integer",

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -38,6 +39,14 @@ func NewConfig(cfgFile string) (*Config, error) {
 type Config struct {
 	Credentials Credentials `toml:"credentials"`
 	Location    string      `toml:"location"`
+	// UseEphemeralStorage is a flag that indicates whether the provider should use
+	// ephemeral storage for the VMs it creates. If true, the provider will use the
+	// ephemeral OS disk feature to create the VMs. Note, the size of the ephemeral
+	// OS disk is determined by the VM size, and the VM size must accomodate the size
+	// of the image.
+	UseEphemeralStorage      bool   `toml:"use_ephemeral_storage"`
+	VirtualNetworkCIDR       string `toml:"virtual_network_cidr"`
+	UseAcceleratedNetworking bool   `toml:"use_accelerated_networking"`
 }
 
 func (c *Config) Validate() error {
@@ -46,6 +55,12 @@ func (c *Config) Validate() error {
 	}
 	if err := c.Credentials.Validate(); err != nil {
 		return fmt.Errorf("failed to validate credentials: %w", err)
+	}
+
+	if c.VirtualNetworkCIDR != "" {
+		if _, _, err := net.ParseCIDR(c.VirtualNetworkCIDR); err != nil {
+			return fmt.Errorf("invalid virtual_network_cidr: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/client/azure.go
+++ b/internal/client/azure.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -74,22 +75,28 @@ func NewAzCLI(cfg *config.Config) (*AzureCli, error) {
 		return nil, err
 	}
 
+	skuCLI, err := armcompute.NewResourceSKUsClient(cfg.Credentials.SubscriptionID, creds, &opts)
+	if err != nil {
+		return nil, err
+	}
+
 	extClient, err := armcompute.NewVirtualMachineExtensionsClient(cfg.Credentials.SubscriptionID, creds, &opts)
 	if err != nil {
 		return nil, err
 	}
 	azCli := &AzureCli{
-		cfg:       cfg,
-		cred:      creds,
-		rgCli:     resourceGroupClient,
-		netCli:    netCli,
-		subnetCli: subnetClient,
-		nsgCli:    nsgClient,
-		nicCli:    nicClient,
-		vmCli:     vmClient,
-		pubIPCli:  publicIPcli,
-		extCli:    extClient,
-		location:  cfg.Location,
+		cfg:            cfg,
+		cred:           creds,
+		rgCli:          resourceGroupClient,
+		netCli:         netCli,
+		subnetCli:      subnetClient,
+		nsgCli:         nsgClient,
+		nicCli:         nicClient,
+		vmCli:          vmClient,
+		pubIPCli:       publicIPcli,
+		extCli:         extClient,
+		location:       cfg.Location,
+		resourceSKUCli: skuCLI,
 	}
 	return azCli, nil
 }
@@ -98,14 +105,15 @@ type AzureCli struct {
 	cfg  *config.Config
 	cred azcore.TokenCredential
 
-	rgCli     *armresources.ResourceGroupsClient
-	netCli    *armnetwork.VirtualNetworksClient
-	subnetCli *armnetwork.SubnetsClient
-	nsgCli    *armnetwork.SecurityGroupsClient
-	nicCli    *armnetwork.InterfacesClient
-	vmCli     *armcompute.VirtualMachinesClient
-	pubIPCli  *armnetwork.PublicIPAddressesClient
-	extCli    *armcompute.VirtualMachineExtensionsClient
+	rgCli          *armresources.ResourceGroupsClient
+	netCli         *armnetwork.VirtualNetworksClient
+	subnetCli      *armnetwork.SubnetsClient
+	nsgCli         *armnetwork.SecurityGroupsClient
+	nicCli         *armnetwork.InterfacesClient
+	vmCli          *armcompute.VirtualMachinesClient
+	pubIPCli       *armnetwork.PublicIPAddressesClient
+	extCli         *armcompute.VirtualMachineExtensionsClient
+	resourceSKUCli *armcompute.ResourceSKUsClient
 
 	location string
 }
@@ -194,7 +202,7 @@ func (a *AzureCli) CreateNetworkSecurityGroup(ctx context.Context, baseName stri
 	return &resp.SecurityGroup, nil
 }
 
-func (a *AzureCli) CreateNetWorkInterface(ctx context.Context, baseName, subnetID, networkSecurityGroupID, publicIPID string) (*armnetwork.Interface, error) {
+func (a *AzureCli) CreateNetWorkInterface(ctx context.Context, baseName, subnetID, networkSecurityGroupID, publicIPID string, acceletatedNetworking bool) (*armnetwork.Interface, error) {
 	interfaceIPConfig := &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 		PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
 		Subnet: &armnetwork.Subnet{
@@ -211,6 +219,7 @@ func (a *AzureCli) CreateNetWorkInterface(ctx context.Context, baseName, subnetI
 	parameters := armnetwork.Interface{
 		Location: to.Ptr(a.location),
 		Properties: &armnetwork.InterfacePropertiesFormat{
+			EnableAcceleratedNetworking: to.Ptr(acceletatedNetworking),
 			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 				{
 					Name:       to.Ptr("ipConfig"),
@@ -256,11 +265,12 @@ func (a *AzureCli) CreatePublicIP(ctx context.Context, baseName string) (*armnet
 	return &resp.PublicIPAddress, err
 }
 
-func (a *AzureCli) CreateVirtualMachine(ctx context.Context, spec *spec.RunnerSpec, networkInterfaceID string, tags map[string]*string) error {
+func (a *AzureCli) CreateVirtualMachine(ctx context.Context, spec *spec.RunnerSpec, networkInterfaceID string, tags map[string]*string, cacheSize int32) error {
 	if spec == nil {
 		return fmt.Errorf("invalid nil runner spec")
 	}
-	properties, err := spec.GetNewVMProperties(networkInterfaceID)
+
+	properties, err := spec.GetNewVMProperties(networkInterfaceID, cacheSize)
 	if err != nil {
 		return fmt.Errorf("failed to get new VM properties: %w", err)
 	}
@@ -292,6 +302,44 @@ func (a *AzureCli) CreateVirtualMachine(ctx context.Context, spec *spec.RunnerSp
 	}
 
 	return nil
+}
+
+func (a *AzureCli) GetMaxEphemeralDiskSize(ctx context.Context, vmSize string) (int32, error) {
+	opts := &armcompute.ResourceSKUsClientListOptions{
+		Filter: to.Ptr(fmt.Sprintf("location eq '%s'", a.location)),
+	}
+	pager := a.resourceSKUCli.NewListPager(opts)
+	for pager.More() {
+		resp, err := pager.NextPage(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get VM size details: %w", err)
+		}
+		if resp.ResourceSKUsResult.Value != nil {
+			for _, val := range resp.ResourceSKUsResult.Value {
+				if *val.ResourceType == "virtualMachines" && *val.Name == vmSize {
+					var ephemeralSupported string
+					var cacheBytes string
+					for _, capability := range val.Capabilities {
+						switch *capability.Name {
+						case "EphemeralOSDiskSupported":
+							ephemeralSupported = *capability.Value
+						case "CachedDiskBytes":
+							cacheBytes = *capability.Value
+						}
+					}
+					if ephemeralSupported == "True" && cacheBytes != "" {
+						asInt64, err := strconv.ParseInt(cacheBytes, 10, 64)
+						if err != nil {
+							return 0, fmt.Errorf("failed to parse cache bytes: %w", err)
+						}
+						inGB := asInt64 / 1024 / 1024 / 1024
+						return int32(inGB), nil
+					}
+				}
+			}
+		}
+	}
+	return 0, fmt.Errorf("failed to get VM size details for %s", vmSize)
 }
 
 func (a *AzureCli) DeleteResourceGroup(ctx context.Context, resourceGroup string, forceDelete bool) error {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -420,14 +420,16 @@ func (r RunnerSpec) GetNewVMProperties(networkInterfaceID string, sizeSpec VMSiz
 		}
 		diffSettings = r.ephemeralDiskSettings(placement)
 		cacheType = to.Ptr(armcompute.CachingTypesReadOnly)
-		diskSize = size
 
-		// If confidential VMs are used with ephemeral storage, 1 GB is reserved.
-		// See: https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks#confidential-vms-using-ephemeral-os-disks
-		// However, we disable confidential VMs for now, when ephemeral storage is used. We'll leave this recalculation of available
-		// space, in case we enable it in the future.
-		if r.Confidential {
-			diskSize = diskSize - 1
+		if diskSize >= size {
+			diskSize = size
+			// If confidential VMs are used with ephemeral storage, 1 GB is reserved.
+			// See: https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks#confidential-vms-using-ephemeral-os-disks
+			// However, we disable confidential VMs for now, when ephemeral storage is used. We'll leave this recalculation of available
+			// space, in case we enable it in the future.
+			if r.Confidential {
+				diskSize = diskSize - 1
+			}
 		}
 	}
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -421,7 +421,7 @@ func (r RunnerSpec) GetNewVMProperties(networkInterfaceID string, sizeSpec VMSiz
 		diffSettings = r.ephemeralDiskSettings(placement)
 		cacheType = to.Ptr(armcompute.CachingTypesReadOnly)
 
-		if diskSize >= size {
+		if diskSize == 0 || diskSize >= size {
 			diskSize = size
 			// If confidential VMs are used with ephemeral storage, 1 GB is reserved.
 			// See: https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks#confidential-vms-using-ephemeral-os-disks

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -1,4 +1,7 @@
 location = "westeurope"
+use_ephemeral_storage = true
+virtual_network_cidr = "10.0.0.0/16"
+use_accelerated_networking = true
 
 [credentials]
 subscription_id = "sample_sub_id"


### PR DESCRIPTION
This change enables the following:

* Using ephemeral disks for VM root disks. This should greatly improve IO in some cases.
* Add accellerated network type
* Allow the tweaking of the VM network CIDR

Fixes #11