### PR TITLE
Move gallery image handling to URNToImageDetails

### DIFF
--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"path"
 	"strconv"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
@@ -262,12 +261,6 @@ func (r RunnerSpec) ImageDetails() (providerUtil.ImageDetails, error) {
 		return providerUtil.ImageDetails{}, fmt.Errorf("no image specified in bootstrap params")
 	}
 
-	if strings.Contains(r.BootstrapParams.Image, "/") {
-		return providerUtil.ImageDetails{
-			ID: r.BootstrapParams.Image,
-		}, nil
-	}
-
 	imgDetails, err := providerUtil.URNToImageDetails(r.BootstrapParams.Image)
 	if err != nil {
 		return providerUtil.ImageDetails{}, fmt.Errorf("failed to get image details: %w", err)
@@ -444,7 +437,11 @@ func (r RunnerSpec) GetNewVMProperties(networkInterfaceID string, sizeSpec VMSiz
 	imageReference := &armcompute.ImageReference{}
 
 	if imgDetails.ID != "" {
-		imageReference.ID = to.Ptr(imgDetails.ID)
+		if imgDetails.IsCommunity {
+			imageReference.CommunityGalleryImageID = to.Ptr(imgDetails.ID)
+		} else {
+			imageReference.ID = to.Ptr(imgDetails.ID)
+		}
 	} else {
 		imageReference.Offer = to.Ptr(imgDetails.Offer)
 		imageReference.Publisher = to.Ptr(imgDetails.Publisher)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -72,14 +72,26 @@ func TagsFromBootstrapParams(bootstrapParams params.BootstrapInstance, controlle
 }
 
 type ImageDetails struct {
-	ID        string
-	Offer     string
-	Publisher string
-	SKU       string
-	Version   string
+	ID          string
+	IsCommunity bool
+	Offer       string
+	Publisher   string
+	SKU         string
+	Version     string
 }
 
 func URNToImageDetails(urn string) (ImageDetails, error) {
+	// Gallery reference
+	if urn[0] == '/' {
+		// One of:
+		// /CommunityGalleries/<gallery>/Images/<name>/Versions/<version>
+		// /subscriptions/<subscription>/resourceGroups/<group>/providers/Microsoft.Compute/galleries/<gallery>/images/<name>/versions/<version>
+		return ImageDetails{
+			ID:          urn,
+			IsCommunity: strings.HasPrefix(urn, "/CommunityGalleries/"),
+		}, nil
+	}
+
 	// MicrosoftWindowsServer:WindowsServer:2022-Datacenter:latest
 	fields := strings.Split(urn, ":")
 	if len(fields) != 4 {


### PR DESCRIPTION
and support community gallery. URNToImageDetails is called by TagsFromBootstrapParams and also needs to handle gallery ids. Community gallery ids need to be passed is a separate field of ImageReference.