### PR TITLE
feat: allow to specify (existing) vnet-subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ To this end, this provider supports the following extra specs schema:
             "items": {
                 "type": "string"
             }
+        },
+        "vnet_subnet_id": {
+            "type": "string",
+            "description": "The ID of the subnet to use for the VM. Must be in the same region as the VM."
         }
     }
 }
@@ -176,7 +180,8 @@ An example extra specs json would look like this:
     },
     "ssh_public_keys": [
         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC2oT7j/+elHY9U2ibgk2R...."
-    ]
+    ],
+    "vnet_subnet_id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,11 @@ To this end, this provider supports the following extra specs schema:
         },
         "vnet_subnet_id": {
             "type": "string",
-            "description": "The ID of the subnet to use for the VM. Must be in the same region as the VM."
+            "description": "The ID of the subnet to use for the VM. Must be in the same region as the VM. This is required if disable_network_isolation is set to true, otherwise it is ignored."
+        },
+        "disable_network_isolation": {
+            "type": "boolean",
+            "description": "Disable network isolation for the VM."
         }
     }
 }
@@ -181,7 +185,8 @@ An example extra specs json would look like this:
     "ssh_public_keys": [
         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC2oT7j/+elHY9U2ibgk2R...."
     ],
-    "vnet_subnet_id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet"
+    "vnet_subnet_id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet",
+    "disable_network_isolation": true
 }
 ```
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -47,6 +48,7 @@ type Config struct {
 	UseEphemeralStorage      bool   `toml:"use_ephemeral_storage"`
 	VirtualNetworkCIDR       string `toml:"virtual_network_cidr"`
 	UseAcceleratedNetworking bool   `toml:"use_accelerated_networking"`
+	VnetSubnetID             string `toml:"vnet_subnet_id"`
 }
 
 func (c *Config) Validate() error {
@@ -61,6 +63,11 @@ func (c *Config) Validate() error {
 		if _, _, err := net.ParseCIDR(c.VirtualNetworkCIDR); err != nil {
 			return fmt.Errorf("invalid virtual_network_cidr: %w", err)
 		}
+	}
+	re := regexp.MustCompile(`/subscriptions/[a-f0-9-]{36}/resourceGroups/[a-zA-Z0-9-]+/providers/Microsoft.Network/virtualNetworks/[a-zA-Z0-9-]+/subnets/[a-zA-Z0-9-]+"`)
+
+	if c.VnetSubnetID != "" && !re.MatchString(c.VnetSubnetID) {
+		return fmt.Errorf("invalid vnet_subnet_id, please use the format: /subscriptions/{subscription_id}/resourceGroups/{resource_group}/providers/Microsoft.Network/virtualNetworks/{vnet_name}/subnets/{subnet_name}")
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	VirtualNetworkCIDR       string `toml:"virtual_network_cidr"`
 	UseAcceleratedNetworking bool   `toml:"use_accelerated_networking"`
 	VnetSubnetID             string `toml:"vnet_subnet_id"`
+	DisableIsolatedNetworks  bool   `toml:"disable_isolated_networks"`
 }
 
 func (c *Config) Validate() error {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -55,7 +55,6 @@ func (v VMSizeEphemeralDiskSizeLimits) EphemeralSettings() (int32, *armcompute.D
 	}
 	if v.ResourceDiskSizeGB > 0 {
 		return v.ResourceDiskSizeGB, to.Ptr(armcompute.DiffDiskPlacementResourceDisk), nil
-
 	}
 	return 0, nil, fmt.Errorf("invalid ephemeral disk size limits")
 }
@@ -183,6 +182,7 @@ func GetRunnerSpecFromBootstrapParams(data params.BootstrapInstance, controllerI
 		UseEphemeralStorage:      cfg.UseEphemeralStorage,
 		VirtualNetworkCIDR:       virtualNetworkCIDR,
 		UseAcceleratedNetworking: cfg.UseAcceleratedNetworking,
+		VnetSubnetID:             cfg.VnetSubnetID,
 	}
 
 	if extraSpecs.UseEphemeralStorage != nil {
@@ -219,6 +219,7 @@ type RunnerSpec struct {
 	UseEphemeralStorage      bool
 	VirtualNetworkCIDR       string
 	UseAcceleratedNetworking bool
+	VnetSubnetID             string
 }
 
 func (r RunnerSpec) Validate() error {
@@ -361,7 +362,6 @@ func (r RunnerSpec) managedDiskSettings() *armcompute.ManagedDiskParameters {
 		params.SecurityProfile = &armcompute.VMDiskSecurityProfile{
 			SecurityEncryptionType: to.Ptr(armcompute.SecurityEncryptionTypesVMGuestStateOnly),
 		}
-
 	}
 	return params
 }

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -183,6 +183,7 @@ func GetRunnerSpecFromBootstrapParams(data params.BootstrapInstance, controllerI
 		VirtualNetworkCIDR:       virtualNetworkCIDR,
 		UseAcceleratedNetworking: cfg.UseAcceleratedNetworking,
 		VnetSubnetID:             cfg.VnetSubnetID,
+		DisableIsolatedNetworks:  cfg.DisableIsolatedNetworks,
 	}
 
 	if extraSpecs.UseEphemeralStorage != nil {
@@ -220,6 +221,7 @@ type RunnerSpec struct {
 	VirtualNetworkCIDR       string
 	UseAcceleratedNetworking bool
 	VnetSubnetID             string
+	DisableIsolatedNetworks  bool
 }
 
 func (r RunnerSpec) Validate() error {


### PR DESCRIPTION
For some reasons it's important in our world that vnet and subnet are not created per runner instance by the provider, but rather an existing vnet/subnet is used.

This allows set a specific subnet (id) to be used for a new instance. This subnet must already exist, if not an instance creation will fail with  "InvalidResourceReference" error.

<sub>Michael Kuhnt <michael.kuhnt@mercedes-benz.com> Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))
</sub>