### PR TITLE
Update build scripts and add GetVersion

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -24,4 +24,4 @@ jobs:
       - run: go version
 
       - name: Run GARM Go Tests
-        run: make go-test
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bin/
+release/
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ USER root
 
 RUN apk add musl-dev gcc libtool m4 autoconf g++ make libblkid util-linux-dev git linux-headers mingw-w64-gcc
 
+RUN wget http://musl.cc/aarch64-linux-musl-cross.tgz -O /tmp/aarch64-linux-musl-cross.tgz && \
+    tar --strip-components=1 -C /usr/local -xzf /tmp/aarch64-linux-musl-cross.tgz && \
+    rm /tmp/aarch64-linux-musl-cross.tgz
+
 ADD ./scripts/build-static.sh /build-static.sh
 RUN chmod +x /build-static.sh
 

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ ROOTDIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 GOPATH ?= $(shell go env GOPATH)
 GO ?= go
 
-IMAGE_TAG = garm-provider-azure-build
+IMAGE_TAG = garm-provider-build
 
 USER_ID=$(shell ((docker --version | grep -q podman) && echo "0" || id -u))
 USER_GROUP=$(shell ((docker --version | grep -q podman) && echo "0" || id -g))
-GARM_PROVIDER_NAME := "garm-provider-azure"
+GARM_PROVIDER_NAME := garm-provider-azure
 
 default: build
 
@@ -24,10 +24,10 @@ build-static:
 	@echo Building
 	docker build --tag $(IMAGE_TAG) .
 	mkdir -p build
-	docker run --rm -e USER_ID=$(USER_ID) -e USER_GROUP=$(USER_GROUP) -v $(PWD)/build:/build/output:z -v $(PWD):/build/garm-provider-azure:z $(IMAGE_TAG) /build-static.sh
+	docker run --rm -e GARM_PROVIDER_NAME=$(GARM_PROVIDER_NAME) -e USER_ID=$(USER_ID) -e USER_GROUP=$(USER_GROUP) -v $(PWD)/build:/build/output:z -v $(PWD):/build/$(GARM_PROVIDER_NAME):z $(IMAGE_TAG) /build-static.sh
 	@echo Binaries are available in $(PWD)/build
 
-test: verify go-test
+test: install-lint-deps verify go-test
 
 install-lint-deps:
 	@$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
@@ -42,13 +42,13 @@ fmt:
 	@$(GO) fmt $$(go list ./...)
 
 fmtcheck:
-	@gofmt -l -s $$(go list ./... | sed -n 's/github.com\/cloudbase\/garm-provider-azure\/\(.*\)/\1/p') | grep ".*\.go"; if [ "$$?" -eq 0 ]; then echo "gofmt check failed; please tun gofmt -w -s"; exit 1;fi
+	@gofmt -l -s $$(go list ./... | sed -n 's/github.com\/cloudbase\/'$(GARM_PROVIDER_NAME)'\/\(.*\)/\1/p') | grep ".*\.go"; if [ "$$?" -eq 0 ]; then echo "gofmt check failed; please tun gofmt -w -s"; exit 1;fi
 
 verify-vendor: ## verify if all the go.mod/go.sum files are up-to-date
 	$(eval TMPDIR := $(shell mktemp -d))
 	@cp -R ${ROOTDIR} ${TMPDIR}
-	@(cd ${TMPDIR}/garm-provider-azure && ${GO} mod tidy)
-	@diff -r -u -q ${ROOTDIR} ${TMPDIR}/garm-provider-azure >/dev/null 2>&1; if [ "$$?" -ne 0 ];then echo "please run: go mod tidy && go mod vendor"; exit 1; fi
+	@(cd ${TMPDIR}/$(GARM_PROVIDER_NAME) && ${GO} mod tidy)
+	@diff -r -u -q ${ROOTDIR} ${TMPDIR}/$(GARM_PROVIDER_NAME) >/dev/null 2>&1; if [ "$$?" -ne 0 ];then echo "please run: go mod tidy && go mod vendor"; exit 1; fi
 	@rm -rf ${TMPDIR}
 
 verify: verify-vendor lint fmtcheck

--- a/main.go
+++ b/main.go
@@ -30,7 +30,22 @@ var signals = []os.Signal{
 	syscall.SIGTERM,
 }
 
+var (
+	// Version is the version of the application
+	Version = "v0.0.0-unknown"
+)
+
 func main() {
+	// This is an unofficial command. It will be added into future versions of the
+	// external provider interface. For now we manually hardcode it here. This is not
+	// used by GARM itself. It is informative for the user to be able to check the version
+	// of the provider.
+	garmCommand := os.Getenv("GARM_COMMAND")
+	if garmCommand == "GetVersion" {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), signals...)
 	defer stop()
 

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -1,16 +1,48 @@
 #!/bin/sh
 
-GARM_SOURCE="/build/garm-provider-azure"
-BIN_DIR="$GARM_SOURCE/bin"
-git config --global --add safe.directory "$GARM_SOURCE"
+GARM_PROVIDER_NAME=${GARM_PROVIDER_NAME:-garm-provider-azure}
+GARM_SOURCE="/build/$GARM_PROVIDER_NAME"
+git config --global --add safe.directory /build/$GARM_PROVIDER_NAME
+cd $GARM_SOURCE
 
-[ ! -d "$BIN_DIR" ] && mkdir -p "$BIN_DIR"
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ ! -z "$GARM_REF" ] && [ "$GARM_REF" != "$CURRENT_BRANCH" ];then
+    git checkout $GARM_REF
+fi
+
+cd $GARM_SOURCE
+
+OUTPUT_DIR="/build/output"
+VERSION=$(git describe --tags --match='v[0-9]*' --dirty --always)
+BUILD_DIR="$OUTPUT_DIR/$VERSION"
+
+
+[ ! -d "$BUILD_DIR/linux" ] && mkdir -p "$BUILD_DIR/linux"
+[ ! -d "$BUILD_DIR/windows" ] && mkdir -p "$BUILD_DIR/windows"
 
 export CGO_ENABLED=1
 USER_ID=${USER_ID:-$UID}
 USER_GROUP=${USER_GROUP:-$(id -g)}
 
+# Garm
 cd $GARM_SOURCE
-go build -mod vendor -o $BIN_DIR/garm-provider-azure -tags osusergo,netgo -ldflags "-linkmode external -extldflags '-static' -s -w" .
 
-chown $USER_ID:$USER_GROUP -R "$BIN_DIR"
+# Linux
+GOOS=linux GOARCH=amd64 go build -mod vendor \
+    -o $BUILD_DIR/linux/amd64/$GARM_PROVIDER_NAME \
+    -tags osusergo,netgo,sqlite_omit_load_extension \
+    -ldflags "-extldflags '-static' -s -w -X main.Version=$VERSION" .
+GOOS=linux GOARCH=arm64 CC=aarch64-linux-musl-gcc go build \
+    -mod vendor \
+    -o $BUILD_DIR/linux/arm64/$GARM_PROVIDER_NAME \
+    -tags osusergo,netgo,sqlite_omit_load_extension \
+    -ldflags "-extldflags '-static' -s -w -X main.Version=$VERSION" .
+
+# Windows
+GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-cc go build -mod vendor \
+    -o $BUILD_DIR/windows/amd64/$GARM_PROVIDER_NAME.exe \
+    -tags osusergo,netgo,sqlite_omit_load_extension \
+    -ldflags "-s -w -X main.Version=$VERSION" .
+
+git checkout $CURRENT_BRANCH || true
+chown $USER_ID:$USER_GROUP -R "$OUTPUT_DIR"

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+echo $GARM_REF
+GARM_PROVIDER_NAME=${GARM_PROVIDER_NAME:-garm-provider-azure}
+
+VERSION=$(git describe --tags --match='v[0-9]*' --dirty --always)
+RELEASE="$PWD/release"
+
+[ ! -d "$RELEASE" ] && mkdir -p "$RELEASE"
+
+if [ ! -z "$GARM_REF" ]; then
+    VERSION=$(git describe --tags --match='v[0-9]*' --always $GARM_REF)
+fi
+
+echo $VERSION
+
+if [ ! -d "build/$VERSION" ]; then
+    echo "missing build/$VERSION"
+    exit 1
+fi
+
+# Windows
+
+if [ ! -d "build/$VERSION/windows/amd64" ];then
+    echo "missing build/$VERSION/windows/amd64"
+    exit 1
+fi
+
+if [ ! -f "build/$VERSION/windows/amd64/$GARM_PROVIDER_NAME.exe" ];then
+    echo "missing build/$VERSION/windows/amd64/$GARM_PROVIDER_NAME.exe"
+    exit 1
+fi
+
+pushd build/$VERSION/windows/amd64
+zip $GARM_PROVIDER_NAME-windows-amd64.zip $GARM_PROVIDER_NAME.exe
+sha256sum $GARM_PROVIDER_NAME-windows-amd64.zip > $GARM_PROVIDER_NAME-windows-amd64.zip.sha256
+mv $GARM_PROVIDER_NAME-windows-amd64.zip $RELEASE
+mv $GARM_PROVIDER_NAME-windows-amd64.zip.sha256 $RELEASE
+popd
+
+# Linux
+OS_ARCHES=("amd64" "arm64")
+
+for arch in ${OS_ARCHES[@]};do
+    if [ ! -f "build/$VERSION/linux/$arch/$GARM_PROVIDER_NAME" ];then
+        echo "missing build/$VERSION/linux/$arch/$GARM_PROVIDER_NAME"
+        exit 1
+    fi
+
+    pushd build/$VERSION/linux/$arch
+    tar czf $GARM_PROVIDER_NAME-linux-$arch.tgz $GARM_PROVIDER_NAME
+    sha256sum $GARM_PROVIDER_NAME-linux-$arch.tgz > $GARM_PROVIDER_NAME-linux-$arch.tgz.sha256
+    mv $GARM_PROVIDER_NAME-linux-$arch.tgz $RELEASE
+    mv $GARM_PROVIDER_NAME-linux-$arch.tgz.sha256 $RELEASE
+    popd
+done


### PR DESCRIPTION
This change updates the build-static.sh script, adds a new make-release.sh, updates the makefile to add new targets and adds a new unofficial command called GetVersion that prints out the version of the provider.

The GetVersion command will be added to the common package in the next release.