### PR TITLE
Feat/add missing toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ subscription_id = "sample_sub_id"
     client_secret = "super secret client secret"
 
     # The managed identity token source is always added to the chain of possible authentication
-    # sources. The client ID can be overwritten if needed. 
+    # sources. The client ID can be overwritten if needed.
     [credentials.managed_identity]
     # The client ID to use. This config value is optional.
     client_id = "sample_client_id"
@@ -164,6 +164,15 @@ To this end, this provider supports the following extra specs schema:
         "disable_isolated_networks": {
             "type": "boolean",
             "description": "Disable network isolation for the VM."
+        },
+        "enable_boot_debug": {
+            "type": "boolean",
+            "description": "Enable cloud-init debug mode. Adds 'set -x' into the cloud-init script."
+        },
+        "disable_updates": {
+            "type": "boolean",
+            "description": "Disable automatic updates on the VM."
+
         }
     },
 	"additionalProperties": false

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,19 @@ type Config struct {
 	UseAcceleratedNetworking bool   `toml:"use_accelerated_networking"`
 	VnetSubnetID             string `toml:"vnet_subnet_id"`
 	DisableIsolatedNetworks  bool   `toml:"disable_isolated_networks"`
+
+	// DisableUdatesOnBoot indicates whether to install or update packages on boot during cloud-init.
+	// If set to true `PackageUpgrade` is set to false and `Packages` is set to an empty list in the cloud-init config.
+	//
+	// This value can NOT be overwritten using extra_specs.
+	DisableUpdatesOnBoot bool `toml:"disable_updates_on_boot"`
+
+	// EnableBootDebug indicates whether to enable debug mode during boot / cloud-init.
+	// If set to true `set -x` is added to the cloud-init config.
+	// Attention: This will might expose sensitive data in the logs! Do not use in production!
+	//
+	// This value can be overwritten using extra_specs.
+	EnableBootDebug bool `toml:"enable_boot_debug"`
 }
 
 func (c *Config) Validate() error {

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1 h1:WpB/QDNLpMw
 github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/cloudbase/garm-provider-common v0.1.2-0.20240411194339-62b33c5d84ec h1:iiWyWZBodRWriKJdBE1UqsvYmTBPOLPiZOK2ds5wlnk=
-github.com/cloudbase/garm-provider-common v0.1.2-0.20240411194339-62b33c5d84ec/go.mod h1:igxJRT3OlykERYc6ssdRQXcb+BCaeSfnucg6I0OSoDc=
 github.com/cloudbase/garm-provider-common v0.1.2 h1:EqSpUjw9rzo4PiUmteHkFtZNWCnRi0QXHRKZ+VA1IPo=
 github.com/cloudbase/garm-provider-common v0.1.2/go.mod h1:igxJRT3OlykERYc6ssdRQXcb+BCaeSfnucg6I0OSoDc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -119,6 +119,14 @@ const (
 				"disable_isolated_networks": {
 					"type": "boolean",
 					"description": "Disable network isolation for the VM."
+				},
+				"enable_boot_debug": {
+					"type": "boolean",
+					"description": "Enable boot debug for the VM."
+				},
+				"disable_updates": {
+					"type": "boolean",
+					"description": "Disable automatic updates on the VM."
 				}
 			},
 			"additionalProperties": false
@@ -184,6 +192,8 @@ type extraSpecs struct {
 	UseAcceleratedNetworking *bool                                     `json:"use_accelerated_networking"`
 	VnetSubnetID             string                                    `json:"vnet_subnet_id"`
 	DisableIsolatedNetworks  *bool                                     `json:"disable_isolated_networks"`
+	EnableBootDebug          *bool                                     `json:"enable_boot_debug"`
+	DisableUpdatesOnBoot     *bool                                     `json:"disable_updates"`
 }
 
 func (e *extraSpecs) cleanInboundPorts() {
@@ -268,6 +278,14 @@ func GetRunnerSpecFromBootstrapParams(data params.BootstrapInstance, controllerI
 		tags[name] = to.Ptr(val)
 	}
 
+	if cfg.DisableUpdatesOnBoot {
+		data.UserDataOptions.DisableUpdatesOnBoot = true
+	}
+
+	if cfg.EnableBootDebug {
+		data.UserDataOptions.EnableBootDebug = true
+	}
+
 	spec := &RunnerSpec{
 		VMSize:                   data.Flavor,
 		AllocatePublicIP:         extraSpecs.AllocatePublicIP,
@@ -305,6 +323,14 @@ func GetRunnerSpecFromBootstrapParams(data params.BootstrapInstance, controllerI
 
 	if !spec.UseEphemeralStorage && spec.DiskSizeGB == 0 {
 		spec.DiskSizeGB = defaultDiskSizeGB
+	}
+
+	if extraSpecs.EnableBootDebug != nil {
+		data.UserDataOptions.EnableBootDebug = *extraSpecs.EnableBootDebug
+	}
+
+	if extraSpecs.DisableUpdatesOnBoot != nil {
+		data.UserDataOptions.DisableUpdatesOnBoot = *extraSpecs.DisableUpdatesOnBoot
 	}
 
 	if err := spec.Validate(); err != nil {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -623,6 +623,9 @@ func (r RunnerSpec) GetNewVMProperties(networkInterfaceID string, sizeSpec VMSiz
 	}
 
 	if r.BootstrapParams.OSType == params.Linux {
+		// Linux computer names can be up to 63 characters long.
+		properties.OSProfile.ComputerName = to.Ptr(r.BootstrapParams.Name[:min(len(r.BootstrapParams.Name), 63)])
+
 		pubKeys := []*armcompute.SSHPublicKey{}
 		fakeKey, err := providerUtil.GenerateFakeKey()
 		if err == nil {


### PR DESCRIPTION
This allows to configure 2 (missing) toggles in this provider. 

The functionality of both toggles is already implemented in the common provider, only the configuration part was missing in this provider.

**Worth noting:**
- I tried to add both toggles similar to the openstack provider, unfortunately the naming of `disable_updates` is not consistent. In the extracspecs it's `disable_updates` but in the config (and in the code) it's `disable_updates_on_boot`.  Anyway, this mixup is now exactly as it is in the garm-provider-openstack.
- Unlike in garm-provider-openstack, we here have a number of toggles that can only be set via extraspecs but not via config .. this awkward and probably needs to be fixed in future?

Also I sneaked in a commit that allows longer hostnames for linux VMs.
