### PR TITLE
feat: allow longer linux computer names than 15 chars

### DIFF
--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -646,6 +646,9 @@ func (r RunnerSpec) GetNewVMProperties(networkInterfaceID string, sizeSpec VMSiz
 	}
 
 	if r.BootstrapParams.OSType == params.Linux {
+		// Linux computer names can be up to 63 characters long.
+		properties.OSProfile.ComputerName = to.Ptr(r.BootstrapParams.Name[:min(len(r.BootstrapParams.Name), 63)])
+
 		pubKeys := []*armcompute.SSHPublicKey{}
 		fakeKey, err := providerUtil.GenerateFakeKey()
 		if err == nil {


### PR DESCRIPTION
.. linux allows up to 63 chars for the hostname.