### PR TITLE
MS Entra Workload Identities implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,27 @@ Copy the binary on the same system where garm is running, and [point to it in th
 
 The config file for this external provider is a simple toml used to configure the azure credentials it needs to spin up virtual machines.
 
-For now, only service principles credentials and azure managed identity are supported. An example can be found [in the testdata folder](./testdata/config.toml).
+For now, service principals, azure managed identities and workload identities are supported. An example can be found [in the testdata folder](./testdata/config.toml).
 
 ```toml
 location = "westeurope"
+use_ephemeral_storage = true
+virtual_network_cidr = "10.0.0.0/16"
+use_accelerated_networking = true
 
 [credentials]
 subscription_id = "sample_sub_id"
 
-    # The service principle service credentials can be used when azure managed identity
+    # The workload identity can be used when other methods are not available
+    # or if a more precise selection of the workload on which to apply permissions is needed.
+    # This seems to be the latest recommended method from Azure.
+    # More information here: https://learn.microsoft.com/en-us/entra/workload-id/workload-identities-overview
+    [credentials.workload_identity]
+    tenant_id = "sample_tenant_id"
+    client_id = "sample_client_id"
+    federated_token_file = "/path/to/federated_token_file"
+
+    # The service principal credentials can be used when azure managed identity
     # is not available.
     [credentials.service_principal]
     # you can create a SP using:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ subscription_id = "sample_sub_id"
     client_secret = "super secret client secret"
 
     # The managed identity token source is always added to the chain of possible authentication
-    # sources. The client ID can be overwritten if needed. 
+    # sources. The client ID can be overwritten if needed.
     [credentials.managed_identity]
     # The client ID to use. This config value is optional.
     client_id = "sample_client_id"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -211,34 +211,7 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestAbsentTokenFile(t *testing.T) {
-	mockData := `
-	location = "westeurope"
-	use_ephemeral_storage = true
-	virtual_network_cidr = "10.10.0.0/24"
-	use_accelerated_networking = true
-	vnet_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-Network/providers/Microsoft.Network/virtualNetworks/vnet-Default/subnets/snet-default"
-	disable_isolated_networks = true
-
-	[credentials]
-	subscription_id = "sample_sub_id"
-
-	[credentials.workload_identity]
-	tenant_id = "sample_tenant_id"
-	client_id = "sample_client_id"
-	federated_token_file = "/path/to/non_existent_token_file"
-	`
-
-	// Create a temporary file
-	tmpFile, err := os.CreateTemp("", "config-*.toml")
-	require.NoError(t, err, "Failed to create temporary file")
-	defer os.Remove(tmpFile.Name())
-
-	_, err = tmpFile.WriteString(mockData)
-	require.NoError(t, err, "Failed to write to temporary file")
-	err = tmpFile.Close()
-	require.NoError(t, err, "Failed to close temporary file")
-
-	// Use the temporary file path as the argument to NewConfig
-	_, err = NewConfig(tmpFile.Name())
+	conf, err := NewConfig("../testdata/config_with_workload_identity.toml")
 	require.Error(t, err, "NewConfig should return an error")
+	require.Nil(t, conf)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -157,20 +157,25 @@ func TestNewConfig(t *testing.T) {
 	[credentials]
 	subscription_id = "sample_sub_id"
 
-    # The service principle service credentials can be used when azure managed identity
-    # is not available.
-    [credentials.service_principal]
-    # you can create a SP using:
-    # az ad sp create-for-rbac --scopes /subscriptions/<subscription ID> --role Contributor
-    tenant_id = "sample_tenant_id"
-    client_id = "sample_client_id"
-    client_secret = "super secret client secret"
+	[credentials.workload_identity]
+	tenant_id = "sample_tenant_id"
+	client_id = "sample_client_id"
+	federated_token_file = "/dev/null"
 
-    # The managed identity token source is always added to the chain of possible authentication
-    # sources. The client ID can be overwritten if needed. 
-    [credentials.managed_identity]
-    # The client ID to use. This config value is optional.
-    client_id = "sample_client_id"
+	# The service principle service credentials can be used when azure managed identity
+	# is not available.
+	[credentials.service_principal]
+	# you can create a SP using:
+	# az ad sp create-for-rbac --scopes /subscriptions/<subscription ID> --role Contributor
+	tenant_id = "sample_tenant_id"
+	client_id = "sample_client_id"
+	client_secret = "super secret client secret"
+
+	# The managed identity token source is always added to the chain of possible authentication
+	# sources. The client ID can be overwritten if needed.
+	[credentials.managed_identity]
+	# The client ID to use. This config value is optional.
+	client_id = "sample_client_id"
 	`
 
 	// Create a temporary file
@@ -194,10 +199,46 @@ func TestNewConfig(t *testing.T) {
 	require.Equal(t, "sample_client_id", cfg.Credentials.SPCredentials.ClientID, "ClientID is not as expected")
 	require.Equal(t, "super secret client secret", cfg.Credentials.SPCredentials.ClientSecret, "ClientSecret is not as expected")
 	require.Equal(t, "sample_client_id", cfg.Credentials.ManagedIdentity.ClientID, "ManagedIdentity ClientID is not as expected")
+	require.Equal(t, "sample_tenant_id", cfg.Credentials.WorkloadIdentity.TenantID, "WorkloadIdentity TenantID is not as expected")
+	require.Equal(t, "sample_client_id", cfg.Credentials.WorkloadIdentity.ClientID, "WorkloadIdentity ClientID is not as expected")
+	require.Equal(t, "/dev/null", cfg.Credentials.WorkloadIdentity.FederatedTokenFile, "WorkloadIdentity FederatedTokenFile is not as expected")
 
 	require.True(t, cfg.UseEphemeralStorage, "UseEphemeralStorage is not as expected")
 	require.Equal(t, "10.10.0.0/24", cfg.VirtualNetworkCIDR, "VirtualNetworkCIDR is not as expected")
 	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-Network/providers/Microsoft.Network/virtualNetworks/vnet-Default/subnets/snet-default", cfg.VnetSubnetID, "VnetSubnetID is not as expected")
 	require.True(t, cfg.UseAcceleratedNetworking, "UseAcceleratedNetworking is not as expected")
 	require.True(t, cfg.DisableIsolatedNetworks, "DisableIsolatedNetworks is not as expected")
+}
+
+func TestAbsentTokenFile(t *testing.T) {
+	mockData := `
+	location = "westeurope"
+	use_ephemeral_storage = true
+	virtual_network_cidr = "10.10.0.0/24"
+	use_accelerated_networking = true
+	vnet_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-Network/providers/Microsoft.Network/virtualNetworks/vnet-Default/subnets/snet-default"
+	disable_isolated_networks = true
+
+	[credentials]
+	subscription_id = "sample_sub_id"
+
+	[credentials.workload_identity]
+	tenant_id = "sample_tenant_id"
+	client_id = "sample_client_id"
+	federated_token_file = "/path/to/non_existent_token_file"
+	`
+
+	// Create a temporary file
+	tmpFile, err := os.CreateTemp("", "config-*.toml")
+	require.NoError(t, err, "Failed to create temporary file")
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString(mockData)
+	require.NoError(t, err, "Failed to write to temporary file")
+	err = tmpFile.Close()
+	require.NoError(t, err, "Failed to close temporary file")
+
+	// Use the temporary file path as the argument to NewConfig
+	_, err = NewConfig(tmpFile.Name())
+	require.Error(t, err, "NewConfig should return an error")
 }

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -6,7 +6,16 @@ use_accelerated_networking = true
 [credentials]
 subscription_id = "sample_sub_id"
 
-    # The service principle service credentials can be used when azure managed identity
+    # The workload identity can be used when other methods are not available
+    # or if a more precise selection of the workload on which to apply permissions is needed.
+    # This seems to be the latest recommended method from Azure.
+    # More information here: https://learn.microsoft.com/en-us/entra/workload-id/workload-identities-overview
+    [credentials.workload_identity]
+    tenant_id = "sample_tenant_id"
+    client_id = "sample_client_id"
+    federated_token_file = "/path/to/federated_token_file"
+
+    # The service principal credentials can be used when azure managed identity
     # is not available.
     [credentials.service_principal]
     # you can create a SP using:

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -25,7 +25,7 @@ subscription_id = "sample_sub_id"
     client_secret = "super secret client secret"
 
     # The managed identity token source is always added to the chain of possible authentication
-    # sources. The client ID can be overwritten if needed. 
+    # sources. The client ID can be overwritten if needed.
     [credentials.managed_identity]
     # The client ID to use. This config value is optional.
     client_id = "sample_client_id"

--- a/testdata/config_with_workload_identity.toml
+++ b/testdata/config_with_workload_identity.toml
@@ -1,0 +1,14 @@
+location = "westeurope"
+use_ephemeral_storage = true
+virtual_network_cidr = "10.10.0.0/24"
+use_accelerated_networking = true
+vnet_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-Network/providers/Microsoft.Network/virtualNetworks/vnet-Default/subnets/snet-default"
+disable_isolated_networks = true
+
+[credentials]
+subscription_id = "sample_sub_id"
+
+    [credentials.workload_identity]
+    tenant_id = "sample_tenant_id"
+    client_id = "sample_client_id"
+    federated_token_file = "/path/to/federated_token_file"


### PR DESCRIPTION
This PR introduces ability to authenticate over Azure using Workload Identity workflow.
This workflow is needed for example if garm is deployed inside an AKS (Azure managed kubernetes cluster), where a User Assigned identity or a System managed identity cannot be used.